### PR TITLE
feat: added phone number extraction to pages.js

### DIFF
--- a/pages.js
+++ b/pages.js
@@ -42,8 +42,8 @@ const extractionForms = [
     },  
     {
         "title": "Phone Number",
-        "explanation": "Extract 10-12 Digit Phone Number from text",
-        "regexPattern": "^[\+]?[(]?[0-9]{3}[)]?\s*[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
+        "explanation": "Extract Phone Number from text (International number must begin with `+`)",
+        "regexPattern": "^(\\+[0-9]{2,3}\\s?)?1?[-.]?\\s?\\(?[0-9]{3}\\)?[\\s.-]?[0-9]{3}[\\s.-]?[0-9]{4}$"
     },
 ];
 

--- a/pages.js
+++ b/pages.js
@@ -34,6 +34,11 @@ const extractionForms = [
         "title": "IP Address",
         "explanation": "Extract all IP Address from text",
         "regexPattern": "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?(\.|$)){4}"
+    },  
+    {
+        "title": "Phone Number",
+        "explanation": "Extract 10-12 Digit Phone Number from text",
+        "regexPattern": "^[\+]?[(]?[0-9]{3}[)]?\s*[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
     },
 ];
 


### PR DESCRIPTION
Here is a starting point for [Issue 6](https://github.com/hammadsaedi/regex-pro/issues/6).

This currently reads up to 12 characters and extracts a 10-12 digit phone number.
I would really appreciate any guidance you can offer in terms of how you may want this regex to function.
For example do you want it to ignore all non-numeric characters?

Please advise on how I can improve or customize to your goals.  Thanks